### PR TITLE
editor structure refactor

### DIFF
--- a/editor/README.md
+++ b/editor/README.md
@@ -32,3 +32,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/import?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Todo
+
+- code lint ( use prettier & other linting library )

--- a/editor/README.md
+++ b/editor/README.md
@@ -36,3 +36,4 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 ## Todo
 
 - code lint ( use prettier & other linting library )
+- same struct code ( declarations, expressions folder ) optimize ( use template ... +etc )

--- a/editor/components/code-preview/index.tsx
+++ b/editor/components/code-preview/index.tsx
@@ -5,71 +5,78 @@ import { useRecoilValue } from "recoil";
 import { stringfy, StringfyLanguage } from "../../../packages/export-string";
 import { currentColiEditorOption } from "../../states/option.state";
 
-const valueToInterfaceData = (data: object) => {
-  let code = [];
+// const valueToInterfaceData = (data: object) => {
+//   let code = [];
 
-  Object.keys(data).map((i) => {
-    switch (typeof data[i]) {
-      case "string":
-        code.push(`${i} : "${data[i]}"`);
-        break;
-      case "object":
-        let objectCodes = {};
-        objectCodes[i] = [];
-        if (data[i] instanceof Array) {
-          data[i].map((_i) => {
-            let tempArray = [];
-            const { type, ...result } = _i;
+//   Object.keys(data).map((i) => {
+//     switch (typeof data[i]) {
+//       case "string":
+//         code.push(`${i} : "${data[i]}"`);
+//         break;
+//       case "object":
+//         let objectCodes = {};
+//         objectCodes[i] = [];
+//         if (data[i] instanceof Array) {
+//           data[i].map((_i) => {
+//             let tempArray = [];
+//             const { type, ...result } = _i;
 
-            Object.keys(result).map((key) => {
-              tempArray.push(`${key} : ${JSON.stringify(_i[key])}`);
-            });
+//             Object.keys(result).map((key) => {
+//               tempArray.push(`${key} : ${JSON.stringify(_i[key])}`);
+//             });
 
-            objectCodes[i].push(
-              `  new ${_i.type}({\n\t\t${tempArray.join(",\n\t\t")}\n\t  })`
-            );
-          });
-          code.push(`${i} : [\n\t${Object.values(objectCodes[i]).join(",\n\t")}\n\t]`);
-        }
-        break;
-      default:
-        break;
-    }
-  });
+//             objectCodes[i].push(
+//               `  new ${_i.type}({\n\t\t${tempArray.join(",\n\t\t")}\n\t  })`
+//             );
+//           });
+//           code.push(
+//             `${i} : [\n\t${Object.values(objectCodes[i]).join(",\n\t")}\n\t]`
+//           );
+//         }
+//         break;
+//       default:
+//         break;
+//     }
+//   });
 
-  return code.join(",\n  ");
-};
+//   return code.join(",\n  ");
+// };
 
-const codePreviewCommentInterface = (params: {
-  interface: any;
+// const codePreviewCommentInterface = (params: {
+//   interface: any;
+//   value: object;
+//   lauangue: StringfyLanguage;
+// }) => {
+//   let comments = "";
+//   if (params.lauangue === "typescript") {
+//     comments = `/***
+// new ${params.interface.name}({
+//   ${valueToInterfaceData(params.value)}
+// })
+// */`;
+//   } else if (params.lauangue === "python") {
+//     comments = `'''
+// new ${params.interface.name}({
+//   ${valueToInterfaceData(params.value)}
+// })
+// '''`;
+//   } else if (params.lauangue === "dart") {
+//     comments = `/**
+// new ${params.interface.name}({
+//   ${valueToInterfaceData(params.value)}
+// })
+// */`;
+//   }
+
+//   return comments;
+// };
+
+export function CodePreview(props: {
   value: object;
-  lauangue: StringfyLanguage;
-}) => {
-  let comments = "";
-  if (params.lauangue === "typescript") {
-    comments = `/***
-new ${params.interface.name}({
-  ${valueToInterfaceData(params.value)}
-})
-*/`;
-  } else if (params.lauangue === "python") {
-    comments = `'''
-new ${params.interface.name}({
-  ${valueToInterfaceData(params.value)}
-})
-'''`;
-  } else if (params.lauangue === "dart") {
-    comments = `/**
-new ${params.interface.name}({
-  ${valueToInterfaceData(params.value)}
-})
-*/`;
-  }
-
-  return comments;
-};
-
-export function CodePreview(props: { value: object; interface: any }) {
+  interface: any;
+  // will be required
+  codeHandler?: (args: { class: any; value: object }) => void;
+}) {
   const editorOption = useRecoilValue(currentColiEditorOption);
 
   return (
@@ -79,12 +86,13 @@ ${stringfy(new props.interface(props.value), {
   language: editorOption.lauangue as StringfyLanguage,
 })}
 
-${codePreviewCommentInterface({
+${props.codeHandler({ class: props.interface, value: props.value })}
+    `}
+      {/* ${codePreviewCommentInterface({
   value: props.value,
   interface: props.interface,
   lauangue: editorOption.lauangue as StringfyLanguage,
-})}
-    `}
+})} */}
     </Wrapper>
   );
 }

--- a/editor/components/code-preview/index.tsx
+++ b/editor/components/code-preview/index.tsx
@@ -75,24 +75,23 @@ export function CodePreview(props: {
   value: object;
   interface: any;
   // will be required
-  codeHandler?: (args: { class: any; value: object }) => void;
+  codeHandler: (args: {
+    class: any;
+    value: object;
+    language: StringfyLanguage;
+  }) => void;
 }) {
-  const editorOption = useRecoilValue(currentColiEditorOption);
+  const { language } = useRecoilValue(currentColiEditorOption);
 
   return (
-    <Wrapper showLineNumbers language={editorOption.lauangue} wrapLines>
+    <Wrapper showLineNumbers language={language} wrapLines>
       {`
 ${stringfy(new props.interface(props.value), {
-  language: editorOption.lauangue as StringfyLanguage,
+  language: language,
 })}
 
-${props.codeHandler({ class: props.interface, value: props.value })}
+${props.codeHandler({ class: props.interface, value: props.value, language })}
     `}
-      {/* ${codePreviewCommentInterface({
-  value: props.value,
-  interface: props.interface,
-  lauangue: editorOption.lauangue as StringfyLanguage,
-})} */}
     </Wrapper>
   );
 }

--- a/editor/components/declarations/import.tsx
+++ b/editor/components/declarations/import.tsx
@@ -13,6 +13,7 @@ import {
 import { CodePreview } from "../code-preview";
 import { stringfy, StringfyLanguage } from "../../../packages/export-string";
 import { currentColiEditorOption } from "../../states/option.state";
+import { CommentExpression } from "coli/lib/expressions/comment";
 
 export interface ImportDeclaration {
   specifiers?: Array<ImportDefaultSpecifier | ImportSpecifier>;
@@ -33,6 +34,17 @@ const fields = [
     lookup: "source",
   },
 ];
+
+const returnExampleImportCode = (args: {
+  class: ImportClass | any;
+  value: ImportDeclaration;
+}) => {
+  const { class: variableClass, value } = args;
+  let code = "";
+  code += `new ${variableClass.name}(\n"${JSON.stringify(value)}\n)`;
+  const comment = new CommentExpression({ style: "multi-line", content: code });
+  return stringfy(comment, { language: "typescript" });
+};
 
 function ImportDeclaration(props: { id: number; data: ImportDeclaration }) {
   const { data, id } = props;
@@ -139,7 +151,11 @@ function ImportDeclaration(props: { id: number; data: ImportDeclaration }) {
           ))}
         </Body>
       </Wrapper>
-      <CodePreview value={declarationValue} interface={ImportClass} />
+      <CodePreview
+        value={declarationValue}
+        interface={ImportClass}
+        codeHandler={returnExampleImportCode}
+      />
     </Positioner>
   );
 }

--- a/editor/components/declarations/import.tsx
+++ b/editor/components/declarations/import.tsx
@@ -38,12 +38,13 @@ const fields = [
 const returnExampleImportCode = (args: {
   class: ImportClass | any;
   value: ImportDeclaration;
+  language: StringfyLanguage;
 }) => {
-  const { class: variableClass, value } = args;
+  const { class: variableClass, value, language } = args;
   let code = "";
   code += `new ${variableClass.name}(\n"${JSON.stringify(value)}\n)`;
   const comment = new CommentExpression({ style: "multi-line", content: code });
-  return stringfy(comment, { language: "typescript" });
+  return stringfy(comment, { language });
 };
 
 function ImportDeclaration(props: { id: number; data: ImportDeclaration }) {
@@ -51,7 +52,7 @@ function ImportDeclaration(props: { id: number; data: ImportDeclaration }) {
   const setDeclaration = useSetRecoilState(
     currentDeclarationAtom<ImportDeclaration>("function", id)
   );
-  const editorOption = useRecoilValue(currentColiEditorOption);
+  const { language } = useRecoilValue(currentColiEditorOption);
   const [declarationValue, setDeclarationValue] = useState<ImportDeclaration>({
     specifiers: [],
     source: "",
@@ -133,7 +134,7 @@ function ImportDeclaration(props: { id: number; data: ImportDeclaration }) {
         <DeclartionTitle lable="IMPORT DECLARTIONS" />
         <CodeBlock>
           {stringfy(new ImportClass(declarationValue), {
-            language: editorOption.lauangue as StringfyLanguage,
+            language,
           })}
         </CodeBlock>
         <Body>

--- a/editor/components/declarations/variable.tsx
+++ b/editor/components/declarations/variable.tsx
@@ -26,13 +26,14 @@ export interface VariableDeclaration {
 const returnExampleVariableCode = (args: {
   class: VariableClass | any;
   value: VariableDeclaration;
+  language: StringfyLanguage;
 }) => {
-  const { class: variableClass, value } = args;
+  const { class: variableClass, value, language } = args;
   const { name, args: values } = value;
   let code = "";
   code += `new ${variableClass.name}(\n"${name}", ${JSON.stringify(values)}\n)`;
   const comment = new CommentExpression({ style: "multi-line", content: code });
-  return stringfy(comment, { language: "typescript" });
+  return stringfy(comment, { language });
 };
 
 function VariableDeclaration(props: {
@@ -43,7 +44,7 @@ function VariableDeclaration(props: {
   const setDeclaration = useSetRecoilState(
     currentDeclarationAtom<VariableDeclaration>("function", id)
   );
-  const editorOption = useRecoilValue(currentColiEditorOption);
+  const { language } = useRecoilValue(currentColiEditorOption);
   const [declarationValue, setDeclarationValue] = useState<VariableDeclaration>(
     {
       name: "",
@@ -71,7 +72,7 @@ function VariableDeclaration(props: {
           {stringfy(
             new VariableClass(declarationValue.name, declarationValue.args),
             {
-              language: editorOption.lauangue as StringfyLanguage,
+              language,
             }
           )}
         </CodeBlock>

--- a/editor/components/declarations/variable.tsx
+++ b/editor/components/declarations/variable.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from "react";
-import { VariableDeclaration as VariableClass, VariableScope } from "coli/lib/declarations/variable";
+import {
+  VariableDeclaration as VariableClass,
+  VariableScope,
+} from "coli/lib/declarations/variable";
 import { Type, Types } from "coli/lib";
 import styled from "@emotion/styled";
 import { useRecoilValue, useSetRecoilState } from "recoil";
@@ -9,6 +12,7 @@ import DeclartionTitle from "./common/title";
 import CodeBlock from "../code-block";
 import { stringfy, StringfyLanguage } from "../../../packages/export-string";
 import { CodePreview } from "../code-preview";
+import { CommentExpression } from "coli/lib/expressions/comment";
 
 export interface VariableDeclaration {
   name: string;
@@ -18,6 +22,18 @@ export interface VariableDeclaration {
     value?: any;
   };
 }
+
+const returnExampleVariableCode = (args: {
+  class: VariableClass | any;
+  value: VariableDeclaration;
+}) => {
+  const { class: variableClass, value } = args;
+  const { name, args: values } = value;
+  let code = "";
+  code += `new ${variableClass.name}(\n"${name}", ${JSON.stringify(values)}\n)`;
+  const comment = new CommentExpression({ style: "multi-line", content: code });
+  return stringfy(comment, { language: "typescript" });
+};
 
 function VariableDeclaration(props: {
   id?: number;
@@ -32,7 +48,7 @@ function VariableDeclaration(props: {
     {
       name: "",
       args: {
-        scope: 'let',
+        scope: "let",
         variableType: Types.any,
         value: "",
       },
@@ -73,7 +89,11 @@ function VariableDeclaration(props: {
           ))}
         </Body>
       </Wrapper>
-      <CodePreview value={declarationValue} interface={VariableClass} />
+      <CodePreview
+        value={declarationValue}
+        interface={VariableClass}
+        codeHandler={returnExampleVariableCode}
+      />
     </Positioner>
   );
 }

--- a/editor/components/expressions/comment.tsx
+++ b/editor/components/expressions/comment.tsx
@@ -30,17 +30,18 @@ const lineValue = [
 const returnExampleCommentCode = (args: {
   class: CommentClass | any;
   value: CommentExpression;
+  language: StringfyLanguage;
 }) => {
-  const { class: commentClass, value } = args;
+  const { class: commentClass, value, language } = args;
   let code = "";
   code += `new ${commentClass.name}(\n${JSON.stringify(value)}\n)`;
   const comment = new CommentClass({ style: "multi-line", content: code });
-  return stringfy(comment, { language: "typescript" });
+  return stringfy(comment, { language });
 };
 
 export default function CommentExpression(props: { data: CommentExpression }) {
   const { data } = props;
-  const editorOption = useRecoilValue(currentColiEditorOption);
+  const { language } = useRecoilValue(currentColiEditorOption);
   const [expressionValue, setExpressionValue] = useState<CommentExpression>({
     style: "",
     content: "",
@@ -70,7 +71,7 @@ export default function CommentExpression(props: { data: CommentExpression }) {
         <DeclartionTitle lable="COMMENT EXPRESSION" />
         <CodeBlock>
           {stringfy(new CommentClass(expressionValue), {
-            language: editorOption.lauangue as StringfyLanguage,
+            language,
           })}
         </CodeBlock>
         <Body>

--- a/editor/components/expressions/comment.tsx
+++ b/editor/components/expressions/comment.tsx
@@ -34,7 +34,6 @@ const returnExampleCommentCode = (args: {
   const { class: commentClass, value } = args;
   let code = "";
   code += `new ${commentClass.name}(\n${JSON.stringify(value)}\n)`;
-  console.log(value.content)
   const comment = new CommentClass({ style: "multi-line", content: code });
   return stringfy(comment, { language: "typescript" });
 };

--- a/editor/components/expressions/comment.tsx
+++ b/editor/components/expressions/comment.tsx
@@ -10,7 +10,6 @@ import { currentDeclarationAtom } from "../../states/declaration.state";
 import AutoGrowTextArea from "../auto-grow-textarea";
 import Selector from "../selector";
 import { CodePreview } from "../code-preview";
-
 export interface CommentExpression {
   style: string;
   content: string;
@@ -28,14 +27,20 @@ const lineValue = [
   },
 ];
 
-export default function CommentExpression(props: {
-  id: number;
-  data: CommentExpression;
-}) {
-  const { id, data } = props;
-  const setExpression = useSetRecoilState(
-    currentDeclarationAtom<CommentExpression>("function", id)
-  );
+const returnExampleCommentCode = (args: {
+  class: CommentClass | any;
+  value: CommentExpression;
+}) => {
+  const { class: commentClass, value } = args;
+  let code = "";
+  code += `new ${commentClass.name}(\n${JSON.stringify(value)}\n)`;
+  console.log(value.content)
+  const comment = new CommentClass({ style: "multi-line", content: code });
+  return stringfy(comment, { language: "typescript" });
+};
+
+export default function CommentExpression(props: { data: CommentExpression }) {
+  const { data } = props;
   const editorOption = useRecoilValue(currentColiEditorOption);
   const [expressionValue, setExpressionValue] = useState<CommentExpression>({
     style: "",
@@ -49,27 +54,17 @@ export default function CommentExpression(props: {
     });
   }, [data]);
 
-  useEffect(() => {
-    setExpression(data);
-  }, [expressionValue]);
-
   const onChangeExpressionValue = (v: string, n: string, k?: number) => {
-    setExpressionValue((d) => {
-      return {
-        ...d,
-        [n]: v == "" ? data[n] : v,
-      };
-    });
+    setExpressionValue((d) => ({
+      ...d,
+      [n]: v == "" ? data[n] : v,
+    }));
   };
 
   const onChangeLineValue = (v: any) => {
-    setExpressionValue((d) => {
-      return {
-        ...d,
-        style: v,
-      };
-    });
+    setExpressionValue((d) => ({ ...d, style: v }));
   };
+
   return (
     <Positioner>
       <Wrapper>
@@ -84,8 +79,11 @@ export default function CommentExpression(props: {
             <div
               style={
                 idx === 1
-                  ? { flexDirection: "column", alignItems: "flex-start" }
-                  : {}
+                  ? {
+                      flexDirection: "column",
+                      alignItems: "flex-start",
+                    }
+                  : null
               }
               className="coli-values"
               key={idx}
@@ -109,7 +107,11 @@ export default function CommentExpression(props: {
           ))}
         </Body>
       </Wrapper>
-      <CodePreview value={expressionValue} interface={CommentClass} />
+      <CodePreview
+        value={expressionValue}
+        interface={CommentClass}
+        codeHandler={returnExampleCommentCode}
+      />
     </Positioner>
   );
 }

--- a/editor/components/header/index.tsx
+++ b/editor/components/header/index.tsx
@@ -2,18 +2,18 @@ import React, { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import { useSetRecoilState } from "recoil";
 import { currentColiEditorOption } from "../../states/option.state";
+import { StringfyLanguage } from "../../../packages/export-string";
 
-type LanguageType = "typescript" | "python" | "dart";
 type ViewType = "block" | "grid";
 
 function Header() {
   const [viewType, setViewType] = useState<ViewType>("block");
-  const [language, setLanguage] = useState<LanguageType>("typescript");
+  const [language, setLanguage] = useState<StringfyLanguage>("typescript");
   const setEditorOption = useSetRecoilState(currentColiEditorOption);
 
   useEffect(() => {
     setEditorOption({
-      lauangue: language,
+      language,
     });
   }, [language]);
 
@@ -35,7 +35,9 @@ function Header() {
       </div>
       <ColiOptions>
         <div className="in-playground">
-          <select onChange={(e) => setLanguage(e.target.value as LanguageType)}>
+          <select
+            onChange={(e) => setLanguage(e.target.value as StringfyLanguage)}
+          >
             <option value="typescript">playground.tsx</option>
             <option value="python">playground.py</option>
             <option value="dart">playground.dart</option>

--- a/editor/components/selector/index.tsx
+++ b/editor/components/selector/index.tsx
@@ -12,7 +12,7 @@ export default function Selector(props: {
       onChange={(e) => props.onChange(e.target.value)}
     >
       {props.options.map((i, _) => (
-        <option value={i.value}>{i.label}</option>
+        <option value={i.value} key={_}>{i.label}</option>
       ))}
     </Wrapper>
   );

--- a/editor/pages/demo/comment/index.tsx
+++ b/editor/pages/demo/comment/index.tsx
@@ -26,7 +26,7 @@ function CoLiCommentDemoPage() {
     <Wrapper>
       <div className="expressions-view">
         {importDefaultData.declarations.map((i, ix) => (
-          <CommentExpression id={ix} data={i} key={ix} />
+          <CommentExpression data={i} key={ix} />
         ))}
       </div>
     </Wrapper>

--- a/editor/states/option.state.ts
+++ b/editor/states/option.state.ts
@@ -1,8 +1,11 @@
 import { atom, selector, ReadOnlySelectorOptions } from "recoil";
+import { StringfyLanguage } from "../../packages/export-string";
 
-export const currentColiEditorOption = atom({
+export const currentColiEditorOption = atom<{
+  language: StringfyLanguage;
+}>({
   key: `editor-option`,
   default: {
-    lauangue: "typescript",
+    language: "typescript",
   },
 });

--- a/packages/export-string/coli-stringfy/expressions/comment.ts
+++ b/packages/export-string/coli-stringfy/expressions/comment.ts
@@ -9,11 +9,11 @@ function Typescript(coli: CommentExpression) {
 
   if (style === "single-line") {
     code = "";
-    content.split("\\n").map((cmt) => (code += `// ${cmt}\n`));
+    content.split("\n").map((cmt) => (code += `// ${cmt}\n`));
   } else {
     code = "";
     code += "/**\n";
-    content.split("\\n").map((cmt) => (code += `* ${cmt}\n`));
+    content.split("\n").map((cmt) => (code += `* ${cmt}\n`));
     code += "*/";
   }
 


### PR DESCRIPTION
# Update
- Changed the structure to process the example code of CoLi from CodePreview in the parents components (declarations, expressions).

# Struct

**prev**
```
demoPage -> (declarations, expressions) -> CodePreview
                                          -------------
                                      generate example code
```

**changed**
```
demoPage -> (delarations, expressions) -> CodePreview
             -------------------------
               generate example code
```
