### PR TITLE
Fix/extract formatting

### DIFF
--- a/packages/coli-export-format-prettier/README.md
+++ b/packages/coli-export-format-prettier/README.md
@@ -1,0 +1,18 @@
+# Default prettier formatter injectable to stringfy package
+
+## Know Issue
+
+prettier won't work on some platform (even standalone), e.g. on figma plugin platform. that is why this package, by default, is not referenced from any other packages.
+
+## The Design
+
+## When (Not) to use
+
+**When to use**
+
+- browser environment
+- nodejs environment
+
+**When Not to use**
+
+- plugin platform

--- a/packages/coli-export-format-prettier/index.ts
+++ b/packages/coli-export-format-prettier/index.ts
@@ -1,0 +1,9 @@
+import parserTypeScript from "prettier/parser-typescript";
+import prettier from "prettier/standalone";
+
+export function formatter(source: string) {
+  return prettier.format(source, {
+    parser: "typescript",
+    plugins: [parserTypeScript],
+  });
+}

--- a/packages/coli-export-format-prettier/package.json
+++ b/packages/coli-export-format-prettier/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "@coli.codes/format-prettier",
+    "version": "0.0.0",
+    "dependencies": {
+        "prettier": "^2.2.1"
+    },
+    "scripts": {
+        "prepack": "tsc"
+    },
+    "devDependencies": {
+        "typescript": "^4.3.2"
+    }
+}

--- a/packages/coli-export-string/package.json
+++ b/packages/coli-export-string/package.json
@@ -2,7 +2,6 @@
     "name": "@coli.codes/export-string",
     "version": "0.0.0",
     "dependencies": {
-        "prettier": "^2.2.1",
         "@coli.codes/escape-string": "0.0.0"
     }
 }

--- a/packages/coli-export-string/stringfy.ts
+++ b/packages/coli-export-string/stringfy.ts
@@ -1,7 +1,5 @@
 import { _abstract, _internal } from "coli";
 import * as CORE from "./core";
-import parserTypeScript from "prettier/parser-typescript";
-import prettier from "prettier/standalone";
 import { coliExportAssignmentStringfy } from "./core";
 
 /*@internal*/
@@ -28,7 +26,8 @@ interface ColiFormatterConfig {
 interface StringfyOptions {
   language: StringfyLanguage;
   arrayDivison?: string;
-  formatter?: ColiFormatterConfig;
+  formatter?: Formatter;
+  formattingOptions?: ColiFormatterConfig;
 }
 
 type useStrinfyFunction = (
@@ -64,19 +63,25 @@ export function stringfy(
 
   if (depth == 0) {
     if (stringfyOptions.formatter) {
-      final = format(final, stringfyOptions.formatter);
+      final = format(
+        final,
+        stringfyOptions.formatter,
+        stringfyOptions.formattingOptions
+      );
     }
   }
 
   return final;
 }
 
-export function format(source: string, opt: ColiFormatterConfig): string {
+type Formatter = (source: string) => string;
+export function format(
+  source: string,
+  formatter: Formatter,
+  opt?: ColiFormatterConfig
+): string {
   try {
-    return prettier.format(source, {
-      parser: "typescript",
-      plugins: [parserTypeScript],
-    });
+    return formatter(source);
   } catch (_) {
     if (opt.throw) {
       throw _;


### PR DESCRIPTION
**Changes**

- coli export string now does not have default formatter
- formatter must be injected on top level usage
- format-prettier is provided as external coli package